### PR TITLE
add tagged versions of docker images

### DIFF
--- a/{{cookiecutter.application_short_name}}/config/ssl/nginx/letsencrypt/dockerfiles/dockerfile
+++ b/{{cookiecutter.application_short_name}}/config/ssl/nginx/letsencrypt/dockerfiles/dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 
 RUN \
   yum install epel-release -y && \

--- a/{{cookiecutter.application_short_name}}/run/cybercom_up
+++ b/{{cookiecutter.application_short_name}}/run/cybercom_up
@@ -17,14 +17,14 @@ if [ -f {{cookiecutter.application_install_directory}}/{{cookiecutter.applicatio
     -v {{cookiecutter.application_short_name}}_mongodata:/data/db:z \
     -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/config.sh:/config.sh \
     -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/addmongouser:/addmongouser \
-    --entrypoint /addmongouser mongo
+    --entrypoint /addmongouser mongo:3
   rm -f {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/thisisfirstrun
 fi
 
 docker run -d --name {{cookiecutter.application_short_name}}_mongo \
   -v {{cookiecutter.application_short_name}}_mongodata:/data/db:z \
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/ssl/backend:/ssl:z \
-  mongo --sslMode requireSSL \
+  mongo:3 --sslMode requireSSL \
         --sslPEMKeyFile /ssl/server/mongodb.pem \
         --sslCAFile /ssl/testca/cacert.pem \
         --auth
@@ -59,7 +59,7 @@ docker run -d --name {{cookiecutter.application_short_name}}_celery \
 
 #memcache
 echo "********* memcached   ********************"
-docker run --name {{cookiecutter.application_short_name}}_memcache -d memcached
+docker run --name {{cookiecutter.application_short_name}}_memcache -d memcached:1.5
 
 #API
 echo "*********  API       *********************"
@@ -90,7 +90,7 @@ docker run -p 80:80 -p 443:443 --name {{cookiecutter.application_short_name}}_ng
   -v ${ssl_key_path}:/etc/ssl/private/selfsigned.key \
   -v ${ssl_cert_path}:/etc/ssl/certs/selfsigned.crt \
   -v ${ssl_dhparam_path}:/etc/ssl/certs/dhparam.pem \
-  -d nginx
+  -d nginx:1
 {% elif cookiecutter.use_ssl == 'LetsEncrypt' %}
 echo "********* Ngnix - Lets Encrypt SSL ********************"
 docker run -p 80:80 -p 443:443 --name {{cookiecutter.application_short_name}}_nginx \
@@ -103,7 +103,7 @@ docker run -p 80:80 -p 443:443 --name {{cookiecutter.application_short_name}}_ng
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/nginx/ssl-params.conf:/etc/nginx/snippets/ssl-params.conf:z \
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/ssl/nginx/letsencrypt:/letsencrypt:z \
   -v ${ssl_dhparam_path}:/etc/ssl/certs/dhparam.pem \
-  -d nginx
+  -d nginx:1
 {% else %}
 echo "********* Ngnix        ********************"
 docker run -p 80:80 --name {{cookiecutter.application_short_name}}_nginx \
@@ -111,7 +111,7 @@ docker run -p 80:80 --name {{cookiecutter.application_short_name}}_nginx \
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/data:/data:z \
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/nginx/nginx.conf:/etc/nginx/nginx.conf:z \
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/nginx/default.conf:/etc/nginx/conf.d/default.conf:z \
-  -d nginx
+  -d nginx:1
 {% endif %}
 
 #Configure and add-ons to containers

--- a/{{cookiecutter.application_short_name}}/run/dbShell
+++ b/{{cookiecutter.application_short_name}}/run/dbShell
@@ -20,7 +20,7 @@ if [ "$RUNNING" == "true" ]; then
   fi
  
   docker exec -it $MONGO_CONTAINER \
-    mongo admin --ssl \
+    mongo:3 admin --ssl \
     --sslPEMKeyFile /ssl/client/mongodb.pem \
     --sslCAFile /ssl/testca/cacert.pem \
     --sslAllowInvalidHostnames \
@@ -29,6 +29,6 @@ if [ "$RUNNING" == "true" ]; then
 else
   docker run -it --rm \
     -v $MONGO_VOLUME:/data/db:z \
-    mongo sh -c "mongod --fork --logpath --quiet && mongo admin"
+    mongo:3 sh -c "mongod --fork --logpath --quiet && mongo admin"
 fi
 {% endraw %}

--- a/{{cookiecutter.application_short_name}}/run/resetDBCreds
+++ b/{{cookiecutter.application_short_name}}/run/resetDBCreds
@@ -6,6 +6,6 @@ docker run -it --rm \
   -v {{cookiecutter.application_short_name}}_mongodata:/data/db:z \
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/config.sh:/config.sh \
   -v {{cookiecutter.application_install_directory}}/{{cookiecutter.application_short_name}}/config/addmongouser:/addmongouser \
-  --entrypoint /addmongouser mongo
+  --entrypoint /addmongouser mongo:3
 
 docker start {{cookiecutter.application_short_name}}_mongo


### PR DESCRIPTION
SSL certificate generation and mongodb configuration breaks under newer images. Locked in tagged versions for containers.